### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - composer install
 script:
   - php vendor/bin/phpcs --standard=PSR12 src/
-  - php vendor/bin/phpunit -c phpunit.xml.dist -v tests/unit/  
+  - php vendor/bin/phpunit -c phpunit.xml.dist -v tests/unit/

--- a/tests/functional/AbstractDatabaseTest.php
+++ b/tests/functional/AbstractDatabaseTest.php
@@ -11,7 +11,7 @@ abstract class AbstractDatabaseTest extends TestCase
 {
     protected Database $db;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->db->createTable('test');
     }

--- a/tests/functional/FileDatabaseTest.php
+++ b/tests/functional/FileDatabaseTest.php
@@ -9,7 +9,7 @@ class FileDatabaseTest extends AbstractDatabaseTest
     protected string $tempFile;
     private string $tempDir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->tempDir = sys_get_temp_dir();
         $tempName = uniqid("DOCLITE_FS_");
@@ -18,7 +18,7 @@ class FileDatabaseTest extends AbstractDatabaseTest
         parent::setup();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         @chmod($this->tempFile, 0777);
         @unlink($this->tempFile);

--- a/tests/functional/FileSystemTest.php
+++ b/tests/functional/FileSystemTest.php
@@ -10,7 +10,7 @@ use Gebler\Doclite\Tests\unit\AbstractFileSystemTest;
 
 class FileSystemTest extends AbstractFileSystemTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fs = new FileSystem();
         $tempDir = sys_get_temp_dir();
@@ -20,7 +20,7 @@ class FileSystemTest extends AbstractFileSystemTest
         $this->separator = \DIRECTORY_SEPARATOR;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         @chmod($this->tempFile, 0777);
         @unlink($this->tempFile);

--- a/tests/functional/MemoryDatabaseTest.php
+++ b/tests/functional/MemoryDatabaseTest.php
@@ -6,13 +6,13 @@ use Gebler\Doclite\MemoryDatabase;
 
 class MemoryDatabaseTest extends AbstractDatabaseTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->db = new MemoryDatabase();
         parent::setup();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/unit/CollectionTest.php
+++ b/tests/unit/CollectionTest.php
@@ -13,7 +13,7 @@ class CollectionTest extends TestCase
     private $db;
     private $collection;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->db = new FakeDatabase();
         $this->collection = new Collection('test', $this->db);

--- a/tests/unit/DatabaseConnectionTest.php
+++ b/tests/unit/DatabaseConnectionTest.php
@@ -15,7 +15,7 @@ class DatabaseConnectionTest extends TestCase
     private $stmt;
     private $conn;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (\PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('These tests only run on PHP 8 due to fake PDO implementation');

--- a/tests/unit/DatabaseTest.php
+++ b/tests/unit/DatabaseTest.php
@@ -17,7 +17,7 @@ class DatabaseTest extends TestCase
     private $db;
     private $readDb;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->conn = $this->createMock(DatabaseConnection::class);
         $this->fs = new FakeFileSystem();

--- a/tests/unit/DocumentTest.php
+++ b/tests/unit/DocumentTest.php
@@ -15,7 +15,7 @@ class DocumentTest extends TestCase
     private $collection;
     private $document;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->db = new FakeDatabase();
         $this->collection = new Collection('test', $this->db);

--- a/tests/unit/FakeFileSystemTest.php
+++ b/tests/unit/FakeFileSystemTest.php
@@ -8,7 +8,7 @@ use Gebler\Doclite\FileSystem\FileSystemInterface;
 
 class FakeFileSystemTest extends AbstractFileSystemTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fs = new FakeFileSystem();
         $this->tempFile = '/foo/bar';

--- a/tests/unit/QueryBuilderTest.php
+++ b/tests/unit/QueryBuilderTest.php
@@ -32,7 +32,7 @@ class QueryBuilderTest extends TestCase
         return 1;
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->queries = [];
         $this->collection = $this->createMock(Collection::class);


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.
- Removing additional white spaces for `.travis.yml` file.